### PR TITLE
Enabling other spaces on hosts file

### DIFF
--- a/bin/selenium-run.bash
+++ b/bin/selenium-run.bash
@@ -24,7 +24,7 @@ fi
 
 
 ## Host File bug sanity check
-grep '127.0.0.1 localhost' /etc/hosts > /dev/null
+grep -P '127.0.0.1\s*localhost' /etc/hosts > /dev/null
 if [[ $? != 0 ]]
 then
     echo "


### PR DESCRIPTION
My default hosts file has a tab instead of a space between the IP and the hostname. That made the `grep` test fail, although the tab is not really a problem.
